### PR TITLE
Revert "Fixed #60: showing now 6 news in frontpage."

### DIFF
--- a/sites/default/conf/views.view.articles.yml
+++ b/sites/default/conf/views.view.articles.yml
@@ -169,7 +169,7 @@ display:
       pager:
         type: some
         options:
-          items_per_page: 6
+          items_per_page: 2
           offset: 0
       query:
         type: views_query


### PR DESCRIPTION
Reverts AsociacionDrupalES/AED#62: theme must be adjusted also:

themes/custom/aed_th/sass/components/views/_view-display-id-block_articles.scss

.view-display-id-block_articles .view-content .views-row {
    width: 45%;
}