### PR TITLE
Do not link to the year taxonomy as the listing is redundant.

### DIFF
--- a/config/core.entity_view_display.node.partner.default.yml
+++ b/config/core.entity_view_display.node.partner.default.yml
@@ -31,7 +31,7 @@ content:
     type: entity_reference_label
     label: inline
     settings:
-      link: true
+      link: false
     third_party_settings: {  }
     weight: 4
     region: content


### PR DESCRIPTION
Fixes https://github.com/AsociacionDrupalES/AED/issues/160